### PR TITLE
Creating test for some bug in serialization/unserialization

### DIFF
--- a/src/test/java/net/agkn/hll/serialization/HllSerializationTest.java
+++ b/src/test/java/net/agkn/hll/serialization/HllSerializationTest.java
@@ -1,0 +1,42 @@
+package net.agkn.hll.serialization;
+
+import net.agkn.hll.HLL;
+import net.agkn.hll.HLLType;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ *
+ * Simple test, should not fail under any circumstances.
+ *
+ * Created by yerenkow
+ */
+public class HllSerializationTest {
+
+    @Test
+    public void runHllSerializeTest () {
+
+        Boolean[] booleans  = new Boolean[] {Boolean.FALSE, Boolean.TRUE};
+
+        for(int log2m =  4; log2m <= 30; log2m ++) {
+            for(int regw =  1; regw <=8; regw ++) {
+                for(int expthr = -1; expthr <= 18; expthr ++ ) {
+                    for (int i = 0; i < HLLType.values().length; i++) {
+                        for (int j = 0; j < booleans.length; j++) {
+                            Boolean aBoolean = booleans[j];
+
+                            HLLType hllType = HLLType.values()[i];
+
+                            HLL hll = new HLL(log2m, regw, expthr, aBoolean, hllType);
+                            HLL hllCopy = HLL.fromBytes(hll.toBytes());
+
+                            Assert.assertNotNull(hllCopy);
+
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Currently, it fails with such messages:

java.lang.IllegalArgumentException: Word length must be larger than 4 and less than or equal to 64. (was: 1)
    at net.agkn.hll.serialization.BigEndianAscendingWordSerializer.<init>(BigEndianAscendingWordSerializer.java:77)
    at net.agkn.hll.serialization.SchemaVersionOne.getSerializer(SchemaVersionOne.java:111)
    at net.agkn.hll.HLL.toBytes(HLL.java:894)
    at net.agkn.hll.HLL.toBytes(HLL.java:847)
    at net.agkn.hll.serialization.HllSerializationTest.runHllSerializeTest(HllSerializationTest.java:31)
