### PR TITLE
Clone for hll

### DIFF
--- a/src/main/java/net/agkn/hll/HLL.java
+++ b/src/main/java/net/agkn/hll/HLL.java
@@ -59,7 +59,7 @@ import net.agkn.hll.util.NumberUtil;
  *
  * @author timon
  */
-public class HLL {
+public class HLL implements Cloneable {
     // minimum and maximum values for the log-base-2 of the number of registers
     // in the HLL
     public static final int MINIMUM_LOG2M_PARAM = 4;
@@ -1017,5 +1017,29 @@ public class HLL {
         }
 
         return hll;
+    }
+
+    @Override
+    public HLL clone() throws CloneNotSupportedException {
+        HLL copy = new HLL(log2m, regwidth, explicitThreshold, sparseThreshold, type);
+
+        switch(type) {
+            case EMPTY:
+                // nothing to be done
+                break;
+            case EXPLICIT:
+                copy.explicitStorage = this.explicitStorage.clone();
+                break;
+            case SPARSE:
+                copy.sparseProbabilisticStorage = this.sparseProbabilisticStorage.clone();
+                break;
+            case FULL:
+                copy.probabilisticStorage = this.probabilisticStorage.clone();
+                break;
+            default:
+                throw new RuntimeException("Unsupported HLL type " + type);
+        }
+
+        return copy;
     }
 }

--- a/src/main/java/net/agkn/hll/HLL.java
+++ b/src/main/java/net/agkn/hll/HLL.java
@@ -74,6 +74,7 @@ public class HLL {
     // constructor and parameter names
     public static final int MINIMUM_EXPTHRESH_PARAM = -1;
     public static final int MAXIMUM_EXPTHRESH_PARAM = 18;
+    public static final int MINIMUM_EXPLICIT_THRESHOLD = 0;
     public static final int MAXIMUM_EXPLICIT_THRESHOLD = (1 << (MAXIMUM_EXPTHRESH_PARAM - 1)/*per storage spec*/);
 
     // ************************************************************************
@@ -288,8 +289,8 @@ public class HLL {
         this.explicitAuto = false;
         this.explicitOff = false;
         this.explicitThreshold = explicitThreshold;
-        if((explicitThreshold < 1) || (explicitThreshold > MAXIMUM_EXPLICIT_THRESHOLD)) {
-            throw new IllegalArgumentException("'explicitThreshold' must be at least 1 and at most " + MAXIMUM_EXPLICIT_THRESHOLD + " (was: " + explicitThreshold + ")");
+        if((explicitThreshold < MINIMUM_EXPLICIT_THRESHOLD) || (explicitThreshold > MAXIMUM_EXPLICIT_THRESHOLD)) {
+            throw new IllegalArgumentException("'explicitThreshold' must be at least " + MINIMUM_EXPLICIT_THRESHOLD + "  and at most " + MAXIMUM_EXPLICIT_THRESHOLD + " (was: " + explicitThreshold + ")");
         }
 
         this.shortWordLength = (regwidth + log2m);

--- a/src/main/java/net/agkn/hll/util/BitVector.java
+++ b/src/main/java/net/agkn/hll/util/BitVector.java
@@ -25,7 +25,7 @@ import net.agkn.hll.serialization.IWordSerializer;
  *
  * @author rgrzywinski
  */
-public class BitVector {
+public class BitVector implements Cloneable {
     // NOTE:  in this context, a word is 64bits
 
     // rather than doing division to determine how a bit index fits into 64bit

--- a/src/test/java/net/agkn/hll/serialization/HLLSerializationTest.java
+++ b/src/test/java/net/agkn/hll/serialization/HLLSerializationTest.java
@@ -55,7 +55,7 @@ public class HLLSerializationTest {
     //       related edge cases that appear as log2m gets even larger.
     // NOTE: This test completed successfully with log2m<=MAXIMUM_LOG2M_PARAM
     //       on 2014-01-30.
-    private static void assertCardinality(final HLLType hllType, final Collection<Long> items) {
+    private void assertCardinality(final HLLType hllType, final Collection<Long> items) {
         for(int log2m=MINIMUM_LOG2M_PARAM; log2m<=16; log2m++) {
             for(int regw=MINIMUM_REGWIDTH_PARAM; regw<=MAXIMUM_REGWIDTH_PARAM; regw++) {
                 for(int expthr=MINIMUM_EXPTHRESH_PARAM; expthr<=MAXIMUM_EXPTHRESH_PARAM; expthr++ ) {
@@ -66,6 +66,14 @@ public class HLLSerializationTest {
                         }
                         HLL copy = HLL.fromBytes(hll.toBytes());
                         assertEquals(copy.cardinality(), hll.cardinality());
+
+                        try {
+                            HLL clone = hll.clone();
+                            assertEquals(clone.cardinality(), hll.cardinality());
+                        } catch (Exception e) {
+                            Assert.fail("Exception catched in clone attempt " + e.getMessage());
+                            e.printStackTrace();
+                        }
                     }
                 }
             }


### PR DESCRIPTION
clone() should be faster than toBytes() -> fromBytes()
