### PR TITLE
Make some calculation use arrays instead of everytime calculation

### DIFF
--- a/src/main/java/net/agkn/hll/HLL.java
+++ b/src/main/java/net/agkn/hll/HLL.java
@@ -139,6 +139,9 @@ public class HLL {
     // the cutoff value of the estimator for using the "small" range cardinality
     // correction formula
     private final double smallEstimatorCutoff;
+    // the cutoff value of the estimator for using the "large" range cardinality
+    // correction formula
+    private final double largeEstimatorCutoff;
 
     // ========================================================================
     /**
@@ -192,6 +195,7 @@ public class HLL {
         this.pwMaxMask = HLLUtil.pwMaxMask(regwidth);
         this.alphaMSquared = HLLUtil.alphaMSquared(m);
         this.smallEstimatorCutoff = HLLUtil.smallEstimatorCutoff(m);
+        this.largeEstimatorCutoff = HLLUtil.largeEstimatorCutoff(log2m, regwidth);
 
         if(expthresh == -1) {
             this.explicitAuto = true;
@@ -284,6 +288,7 @@ public class HLL {
         this.pwMaxMask = HLLUtil.pwMaxMask(regwidth);
         this.alphaMSquared = HLLUtil.alphaMSquared(m);
         this.smallEstimatorCutoff = HLLUtil.smallEstimatorCutoff(m);
+        this.largeEstimatorCutoff = HLLUtil.largeEstimatorCutoff(log2m, regwidth);
 
         this.explicitAuto = false;
         this.explicitOff = false;
@@ -546,7 +551,7 @@ public class HLL {
         final double estimator = alphaMSquared / sum;
         if((numberOfZeroes != 0) && (estimator < smallEstimatorCutoff)) {
             return HLLUtil.smallEstimator(m, numberOfZeroes);
-        } else if(estimator <= HLLUtil.largeEstimatorCutoff(log2m, regwidth)) {
+        } else if(estimator <= largeEstimatorCutoff) {
             return estimator;
         } else {
             return HLLUtil.largeEstimator(log2m, regwidth, estimator);
@@ -580,7 +585,7 @@ public class HLL {
         final double estimator = alphaMSquared / sum;
         if((numberOfZeroes != 0) && (estimator < smallEstimatorCutoff)) {
             return HLLUtil.smallEstimator(m, numberOfZeroes);
-        } else if(estimator <= HLLUtil.largeEstimatorCutoff(log2m, regwidth)) {
+        } else if(estimator <= largeEstimatorCutoff) {
             return estimator;
         } else {
             return HLLUtil.largeEstimator(log2m, regwidth, estimator);

--- a/src/main/java/net/agkn/hll/util/HLLUtil.java
+++ b/src/main/java/net/agkn/hll/util/HLLUtil.java
@@ -16,6 +16,8 @@ package net.agkn.hll.util;
  * limitations under the License.
  */
 
+import net.agkn.hll.HLL;
+
 /**
  * Static functions for computing constants and parameters used in the HLL
  * algorithm.
@@ -23,6 +25,55 @@ package net.agkn.hll.util;
  * @author timon
  */
 public final class HLLUtil {
+    /**
+     * The set of pwMaxMasks
+     * is used as a quick way for calculating by this formula:
+     *   int maxRegisterValue = (1 << registerSizeInBits) - 1;
+     *   // Mask with all bits set except for (maxRegisterValue - 1) least significant bits (see #addRaw())
+     *   return ~((1L << (maxRegisterValue - 1)) - 1);
+     *
+     * @see #pwMaxMask(int)
+     */
+    private static final long[] PW_MASK = {
+            ~((1L << (((1 << 0) - 1) - 1)) - 1),
+            ~((1L << (((1 << 1) - 1) - 1)) - 1),
+            ~((1L << (((1 << 2) - 1) - 1)) - 1),
+            ~((1L << (((1 << 3) - 1) - 1)) - 1),
+            ~((1L << (((1 << 4) - 1) - 1)) - 1),
+            ~((1L << (((1 << 5) - 1) - 1)) - 1),
+            ~((1L << (((1 << 6) - 1) - 1)) - 1),
+            ~((1L << (((1 << 7) - 1) - 1)) - 1),
+            ~((1L << (((1 << 8) - 1) - 1)) - 1)
+    };
+
+    /**
+     * The set of twoToL's
+     * is used as a quick way for calculating by this formula:
+     *
+     *     int maxRegisterValue = (1 << registerSizeInBits) - 1;
+     *     // since 1 is added to p(w) only maxRegisterValue - 1 bits are inspected
+     *     final int pwBits = (maxRegisterValue - 1);
+     *     final int totalBits = (pwBits + log2m);
+     *     final long twoToL = (1L << totalBits);
+     *
+     *
+     *     Array is one-dimensional, and can be accessed by using index [REG_WIDTH_INDEX_MULTIPLIER*regWidth + log2m]
+     *     no values for regWidth = 0, and for log2m[0..3]
+     *     A bit overhead by size, but structure is simple and logical, without magic offsets
+     * @see #largeEstimatorCutoff(int, int), #largeEstimator(int, int, double),
+     */
+    private static final long[] TWO_TO_L = new long[(HLL.MAXIMUM_REGWIDTH_PARAM + 1)*(HLL.MAXIMUM_LOG2M_PARAM + 1)];
+
+    private static final int REG_WIDTH_INDEX_MULTIPLIER = HLL.MAXIMUM_LOG2M_PARAM + 1;
+
+    static {
+        for(int regWidth = HLL.MINIMUM_REGWIDTH_PARAM; regWidth <= HLL.MAXIMUM_REGWIDTH_PARAM; regWidth++) {
+            for(int log2m = HLL.MINIMUM_LOG2M_PARAM ; log2m <= HLL.MAXIMUM_LOG2M_PARAM; log2m++) {
+                TWO_TO_L[REG_WIDTH_INDEX_MULTIPLIER*regWidth + log2m] = (1L << (((1 << regWidth) - 1 - 1) + log2m));
+            }
+        }
+    }
+
     // ************************************************************************
     /**
      * Computes the bit-width of HLL registers necessary to estimate a set of
@@ -79,9 +130,7 @@ public final class HLLUtil {
      * @see #registerBitSize(long)
      */
     public static long pwMaxMask(final int registerSizeInBits) {
-        int maxRegisterValue = (1 << registerSizeInBits) - 1;
-        // Mask with all bits set except for (maxRegisterValue - 1) least significant bits (see #addRaw())
-        return ~((1L << (maxRegisterValue - 1)) - 1);
+        return PW_MASK[registerSizeInBits];
     }
 
     // ========================================================================
@@ -121,12 +170,7 @@ public final class HLLUtil {
      * @see #largeEstimator(int, int, double)
      */
     public static double largeEstimatorCutoff(final int log2m, final int registerSizeInBits) {
-        int maxRegisterValue = (1 << registerSizeInBits) - 1;
-        // since 1 is added to p(w) only maxRegisterValue - 1 bits are inspected
-        final int pwBits = (maxRegisterValue - 1);
-        final int totalBits = (pwBits + log2m);
-        final long twoToL = (1L << totalBits);
-        return (double)twoToL/30;
+        return (double) (TWO_TO_L[REG_WIDTH_INDEX_MULTIPLIER*registerSizeInBits + log2m])/30;
     }
 
     /**
@@ -140,12 +184,7 @@ public final class HLLUtil {
      * @return a corrected cardinality estimate.
      */
     public static double largeEstimator(final int log2m, final int registerSizeInBits, final double estimator) {
-        int maxRegisterValue = (1 << registerSizeInBits) - 1;
-        // since 1 is added to p(w) only maxRegisterValue - 1 bits are inspected
-        final int pwBits = (maxRegisterValue - 1);
-        final int totalBits = (pwBits + log2m);
-        final long twoToL = (1L << totalBits);
-
-        return (-1 * twoToL) * Math.log(1.0 - (estimator/twoToL));
+        return (-1 * TWO_TO_L[REG_WIDTH_INDEX_MULTIPLIER*registerSizeInBits + log2m])
+                * Math.log(1.0 - (estimator/TWO_TO_L[REG_WIDTH_INDEX_MULTIPLIER*registerSizeInBits + log2m]));
     }
 }


### PR DESCRIPTION
This pull request includes previous one (about caching largeEstimatorCutoff), so feel free accept anything from either one, or reimplement my proposed changes :)
