### PR TITLE
Allow HLL objects to be serialized.

### DIFF
--- a/src/main/java/net/agkn/hll/HLL.java
+++ b/src/main/java/net/agkn/hll/HLL.java
@@ -16,6 +16,7 @@ package net.agkn.hll;
  * limitations under the License.
  */
 
+import java.io.Serializable;
 import java.util.Arrays;
 
 import it.unimi.dsi.fastutil.ints.Int2ByteOpenHashMap;
@@ -59,7 +60,7 @@ import net.agkn.hll.util.NumberUtil;
  *
  * @author timon
  */
-public class HLL implements Cloneable {
+public class HLL implements Cloneable, Serializable {
     // minimum and maximum values for the log-base-2 of the number of registers
     // in the HLL
     public static final int MINIMUM_LOG2M_PARAM = 4;


### PR DESCRIPTION
Hi there,

Thanks a lot for the great library, and more so for the thorough article describing the algorithm - it was the only one of several that I was able to digest.

I don't have much Java experience so forgive me if I've overlooked anything, but I'm using `HLL` objects in my Scala/Akka project, which wants to use Java serialization - I was able to get this working simply by implementing `java.io.Serializable`, as found in this pull request.

Thanks again!
