### PR TITLE
Migrate from fastutil to HPPC. Randomize tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.classpath
+.project
+.settings/
+target/

--- a/pom.xml
+++ b/pom.xml
@@ -155,9 +155,9 @@
         </dependency>
 
         <dependency>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-          <version>4.10</version>
+          <groupId>com.carrotsearch.randomizedtesting</groupId>
+          <artifactId>randomizedtesting-runner</artifactId>
+          <version>2.1.14</version>
           <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -154,13 +154,11 @@
           <version>0.7.1</version>
         </dependency>
 
-        <!-- NOTE:  the "jdk15" classifier is "JDK 1.5+" -->
         <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
-            <version>${testng-version}</version>
-            <scope>test</scope>
-            <classifier>jdk15</classifier>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+          <version>4.10</version>
+          <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -172,7 +170,5 @@
         <!-- Testing versions -->
         <easymock-version>3.0</easymock-version>
         <powermock-version>1.4.8</powermock-version>
-        <testng-version>5.7</testng-version>
-        <fastutil-version>6.5.11</fastutil-version>
     </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
+                <version>1.6</version>
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>
@@ -148,30 +149,11 @@
     <dependencies>
         <!-- Production dependencies :: Default scope -->
         <dependency>
-            <groupId>it.unimi.dsi</groupId>
-            <artifactId>fastutil</artifactId>
-            <version>${fastutil-version}</version>
+          <groupId>com.carrotsearch</groupId>
+          <artifactId>hppc</artifactId>
+          <version>0.7.1</version>
         </dependency>
 
-        <!-- Test dependencies :: Test scope -->
-        <dependency>
-            <groupId>org.easymock</groupId>
-            <artifactId>easymock</artifactId>
-            <version>${easymock-version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <version>${powermock-version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-easymock</artifactId>
-            <version>${powermock-version}</version>
-            <scope>test</scope>
-        </dependency>
         <!-- NOTE:  the "jdk15" classifier is "JDK 1.5+" -->
         <dependency>
             <groupId>org.testng</groupId>

--- a/src/main/java/net/agkn/hll/HLL.java
+++ b/src/main/java/net/agkn/hll/HLL.java
@@ -427,8 +427,7 @@ public class HLL implements Cloneable {
         // NOTE:  no +1 as in paper since 0-based indexing
         final int j = (int)(rawValue & mBitsMask);
 
-        assert sparseProbabilisticStorage.containsKey(j);
-        final byte currentValue = sparseProbabilisticStorage.get(j);
+        final byte currentValue = sparseProbabilisticStorage.getOrDefault(j, (byte) 0);
         if(p_w > currentValue) {
             sparseProbabilisticStorage.put(j, p_w);
         }
@@ -546,8 +545,7 @@ public class HLL implements Cloneable {
         double sum = 0;
         int numberOfZeroes = 0/*"V" in the paper*/;
         for(int j=0; j<m; j++) {
-            assert sparseProbabilisticStorage.containsKey(j); 
-            final long register = sparseProbabilisticStorage.get(j);
+            final long register = sparseProbabilisticStorage.getOrDefault(j, (byte) 0);
 
             sum += 1.0 / (1L << register);
             if(register == 0L) numberOfZeroes++;

--- a/src/main/java/net/agkn/hll/HLL.java
+++ b/src/main/java/net/agkn/hll/HLL.java
@@ -704,7 +704,7 @@ public class HLL implements Cloneable {
                         sparseProbabilisticStorage = other.sparseProbabilisticStorage.clone();
                     } else {
                         initializeStorage(HLLType.FULL);
-                        for(IntByteCursor c : sparseProbabilisticStorage) {
+                        for(IntByteCursor c : other.sparseProbabilisticStorage) {
                           final int registerIndex = c.key;
                           final byte registerValue = c.value;
                           probabilisticStorage.setMaxRegister(registerIndex, registerValue);
@@ -746,7 +746,7 @@ public class HLL implements Cloneable {
                         sparseProbabilisticStorage = other.sparseProbabilisticStorage.clone();
                     } else {
                         initializeStorage(HLLType.FULL);
-                        for(IntByteCursor c : sparseProbabilisticStorage) {
+                        for(IntByteCursor c : other.sparseProbabilisticStorage) {
                           final int registerIndex = c.key;
                           final byte registerValue = c.value;
                           probabilisticStorage.setMaxRegister(registerIndex, registerValue);

--- a/src/main/java/net/agkn/hll/util/HLLUtil.java
+++ b/src/main/java/net/agkn/hll/util/HLLUtil.java
@@ -59,7 +59,7 @@ public final class HLLUtil {
      *
      * @see #largeEstimator(int, int, double)
      * @see #largeEstimatorCutoff(int, int)
-     * @see <a href='http://research.neustar.biz/2013/01/24/hyperloglog-googles-take-on-engineering-hll/'>Blog post with section on 2^L</a>
+     * @see "<a href='http://research.neustar.biz/2013/01/24/hyperloglog-googles-take-on-engineering-hll/'>Blog post with section on 2^L</a>"
      */
     private static final double[] TWO_TO_L = new double[(HLL.MAXIMUM_REGWIDTH_PARAM + 1) * (HLL.MAXIMUM_LOG2M_PARAM + 1)];
 
@@ -178,7 +178,7 @@ public final class HLLUtil {
      * @param  registerSizeInBits the size of the HLL registers, in bits.
      * @return the cutoff for the large range correction.
      * @see #largeEstimator(int, int, double)
-     * @see <a href='http://research.neustar.biz/2013/01/24/hyperloglog-googles-take-on-engineering-hll/'>Blog post with section on 64 bit hashes and "large range correction" cutoff</a>
+     * @see "<a href='http://research.neustar.biz/2013/01/24/hyperloglog-googles-take-on-engineering-hll/'>Blog post with section on 64 bit hashes and 'large range correction' cutoff</a>"
      */
     public static double largeEstimatorCutoff(final int log2m, final int registerSizeInBits) {
         return (TWO_TO_L[(REG_WIDTH_INDEX_MULTIPLIER * registerSizeInBits) + log2m]) / 30.0;
@@ -193,7 +193,7 @@ public final class HLLUtil {
      * @param  registerSizeInBits the size of the HLL registers, in bits.
      * @param  estimator the original estimator ("E" in the paper).
      * @return a corrected cardinality estimate.
-     * @see <a href='http://research.neustar.biz/2013/01/24/hyperloglog-googles-take-on-engineering-hll/'>Blog post with section on 64 bit hashes and "large range correction"</a>
+     * @see "<a href='http://research.neustar.biz/2013/01/24/hyperloglog-googles-take-on-engineering-hll/'>Blog post with section on 64 bit hashes and 'large range correction'</a>"
      */
     public static double largeEstimator(final int log2m, final int registerSizeInBits, final double estimator) {
         final double twoToL = TWO_TO_L[(REG_WIDTH_INDEX_MULTIPLIER * registerSizeInBits) + log2m];

--- a/src/test/java/net/agkn/hll/ExplicitHLLTest.java
+++ b/src/test/java/net/agkn/hll/ExplicitHLLTest.java
@@ -16,17 +16,18 @@ package net.agkn.hll;
  * limitations under the License.
  */
 
-import static org.powermock.reflect.Whitebox.getInternalState;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
-import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 
 import java.util.HashSet;
 import java.util.Random;
 
 import net.agkn.hll.serialization.ISchemaVersion;
 import net.agkn.hll.serialization.SerializationUtil;
+
 import org.testng.annotations.Test;
+
+import com.carrotsearch.hppc.LongHashSet;
 
 /**
  * Tests {@link HLL} of type {@link HLLType#EXPLICIT}.
@@ -222,8 +223,8 @@ public class ExplicitHLLTest {
      * Asserts that values in both sets are exactly equal.
      */
     private static void assertElementsEqual(final HLL hllA, final HLL hllB) {
-        final LongOpenHashSet internalSetA = (LongOpenHashSet)getInternalState(hllA, "explicitStorage");
-        final LongOpenHashSet internalSetB = (LongOpenHashSet)getInternalState(hllB, "explicitStorage");
+        final LongHashSet internalSetA = hllA.explicitStorage;
+        final LongHashSet internalSetB = hllB.explicitStorage;
 
         assertTrue(internalSetA.equals(internalSetB));
     }

--- a/src/test/java/net/agkn/hll/ExplicitHLLTest.java
+++ b/src/test/java/net/agkn/hll/ExplicitHLLTest.java
@@ -16,16 +16,14 @@ package net.agkn.hll;
  * limitations under the License.
  */
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
+import static org.junit.Assert.*;
+import org.junit.Test;
 
 import java.util.HashSet;
 import java.util.Random;
 
 import net.agkn.hll.serialization.ISchemaVersion;
 import net.agkn.hll.serialization.SerializationUtil;
-
-import org.testng.annotations.Test;
 
 import com.carrotsearch.hppc.LongHashSet;
 

--- a/src/test/java/net/agkn/hll/ExplicitHLLTest.java
+++ b/src/test/java/net/agkn/hll/ExplicitHLLTest.java
@@ -16,23 +16,22 @@ package net.agkn.hll;
  * limitations under the License.
  */
 
-import static org.junit.Assert.*;
 import org.junit.Test;
 
 import java.util.HashSet;
-import java.util.Random;
 
 import net.agkn.hll.serialization.ISchemaVersion;
 import net.agkn.hll.serialization.SerializationUtil;
 
 import com.carrotsearch.hppc.LongHashSet;
+import com.carrotsearch.randomizedtesting.RandomizedTest;
 
 /**
  * Tests {@link HLL} of type {@link HLLType#EXPLICIT}.
  *
  * @author timon
  */
-public class ExplicitHLLTest {
+public class ExplicitHLLTest extends RandomizedTest {
     /**
      * Tests basic set semantics of {@link HLL#addRaw(long)}.
      */
@@ -179,11 +178,9 @@ public class ExplicitHLLTest {
         final HashSet<Long> canonical = new HashSet<Long>();
         final HLL hll = newHLL(explicitThreshold);
 
-        final long seed = 1L/*constant so results are reproducible*/;
-        final Random random = new Random(seed);
         for(int i=0;i<explicitThreshold;i++){
-            long randomLong = random.nextLong();
-            canonical.add(new Long(randomLong));
+            long randomLong = randomLong();
+            canonical.add(randomLong);
             hll.addRaw(randomLong);
         }
         final int canonicalCardinality = canonical.size();

--- a/src/test/java/net/agkn/hll/FullHLLTest.java
+++ b/src/test/java/net/agkn/hll/FullHLLTest.java
@@ -16,7 +16,6 @@ package net.agkn.hll;
  * limitations under the License.
  */
 
-import static org.powermock.reflect.Whitebox.getInternalState;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.assertFalse;
@@ -163,7 +162,7 @@ public class FullHLLTest {
         { // scoped locally for sanity
             final int regwidth = 4;
             final HLL hll = new HLL(log2m, regwidth, 128/*explicitThreshold, arbitrary, unused*/, 256/*sparseThreshold, arbitrary, unused*/, HLLType.FULL);
-            final BitVector bitVector = (BitVector)getInternalState(hll, "probabilisticStorage")/*for testing convenience*/;
+            final BitVector bitVector = hll.probabilisticStorage;
 
             // lower-bounds of the register
             hll.addRaw(0x000000000000001L/*'j'=1*/);
@@ -210,7 +209,7 @@ public class FullHLLTest {
         { // scoped locally for sanity
             final int regwidth = 5;
             final HLL hll = new HLL(log2m, regwidth, 128/*explicitThreshold, arbitrary, unused*/, 256/*sparseThreshold, arbitrary, unused*/, HLLType.FULL);
-            final BitVector bitVector = (BitVector)getInternalState(hll, "probabilisticStorage")/*for testing convenience*/;
+            final BitVector bitVector = hll.probabilisticStorage;
 
             // lower-bounds of the register
             hll.addRaw(0x0000000000000001L/*'j'=1*/);
@@ -256,7 +255,7 @@ public class FullHLLTest {
         final int m = 1 << log2m;
 
         final HLL hll = new HLL(log2m, regwidth, 128/*explicitThreshold, arbitrary, unused*/, 256/*sparseThreshold, arbitrary, unused*/, HLLType.FULL);
-        final BitVector bitVector = (BitVector)getInternalState(hll, "probabilisticStorage")/*for testing convenience*/;
+        final BitVector bitVector = hll.probabilisticStorage;
         for(int i=0; i<m; i++)
             bitVector.setRegister(i, i);
 
@@ -338,8 +337,8 @@ public class FullHLLTest {
      * Asserts that the two HLLs are register-wise equal.
      */
     private static void assertElementsEqual(final HLL hllA, final HLL hllB) {
-        final BitVector bitVectorA = (BitVector)getInternalState(hllA, "probabilisticStorage")/*for testing convenience*/;
-        final BitVector bitVectorB = (BitVector)getInternalState(hllA, "probabilisticStorage")/*for testing convenience*/;
+        final BitVector bitVectorA = hllA.probabilisticStorage;
+        final BitVector bitVectorB = hllA.probabilisticStorage;
 
         final LongIterator iterA = bitVectorA.registerIterator();
         final LongIterator iterB = bitVectorB.registerIterator();

--- a/src/test/java/net/agkn/hll/FullHLLTest.java
+++ b/src/test/java/net/agkn/hll/FullHLLTest.java
@@ -16,17 +16,14 @@ package net.agkn.hll;
  * limitations under the License.
  */
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.assertFalse;
+import static org.junit.Assert.*;
+import org.junit.Test;
 
 import net.agkn.hll.serialization.ISchemaVersion;
 import net.agkn.hll.serialization.SerializationUtil;
 import net.agkn.hll.util.BitVector;
 import net.agkn.hll.util.HLLUtil;
 import net.agkn.hll.util.LongIterator;
-
-import org.testng.annotations.Test;
 
 /**
  * Tests {@link HLL} of type {@link HLLType#FULL}.

--- a/src/test/java/net/agkn/hll/FullHLLTest.java
+++ b/src/test/java/net/agkn/hll/FullHLLTest.java
@@ -335,7 +335,7 @@ public class FullHLLTest {
      */
     private static void assertElementsEqual(final HLL hllA, final HLL hllB) {
         final BitVector bitVectorA = hllA.probabilisticStorage;
-        final BitVector bitVectorB = hllA.probabilisticStorage;
+        final BitVector bitVectorB = hllB.probabilisticStorage;
 
         final LongIterator iterA = bitVectorA.registerIterator();
         final LongIterator iterB = bitVectorB.registerIterator();

--- a/src/test/java/net/agkn/hll/IntegrationTestGenerator.java
+++ b/src/test/java/net/agkn/hll/IntegrationTestGenerator.java
@@ -26,6 +26,7 @@ import net.agkn.hll.serialization.ISchemaVersion;
 import net.agkn.hll.serialization.SerializationUtil;
 import net.agkn.hll.util.NumberUtil;
 import static net.agkn.hll.ProbabilisticTestUtil.constructHLLValue;
+import static com.carrotsearch.randomizedtesting.RandomizedTest.*;
 
 /**
  * Generates test files for testing other implementations of HLL
@@ -37,8 +38,6 @@ public class IntegrationTestGenerator {
     // ************************************************************************
     // directory to output the generated tests
     private static final String OUTPUT_DIRECTORY = "/tmp/hll_test/";
-    // seed to make results reproducible
-    private static final long SEED = 1L;
 
     // ------------------------------------------------------------------------
     // configurations for HLLs, should mirror settings in PostgreSQL impl. tests
@@ -114,14 +113,12 @@ public class IntegrationTestGenerator {
     private static void globalStepTest(final ISchemaVersion schemaVersion) throws IOException {
         final FileWriter output = openOutput(schemaVersion, "comprehensive_promotion", TestType.ADD);
 
-        final Random random = new Random(SEED);
-
         // the accumulator, starts empty
         final HLL hll = newHLL(HLLType.EMPTY);
         initLineAdd(output, hll, schemaVersion);
 
         for(int i=0; i<10000/*arbitrary*/; i++) {
-            cumulativeAddLine(output, hll, random.nextLong(), schemaVersion);
+            cumulativeAddLine(output, hll, randomLong(), schemaVersion);
         }
 
         output.flush();
@@ -223,7 +220,7 @@ public class IntegrationTestGenerator {
     private static void sparseRandomTest(final ISchemaVersion schemaVersion) throws IOException {
         final FileWriter output = openOutput(schemaVersion, "sparse_random", TestType.ADD);
 
-        final Random random = new Random(SEED);
+        final Random random = new Random(randomLong());
 
         // the accumulator, starts empty
         final HLL hll = newHLL(HLLType.SPARSE);
@@ -291,7 +288,7 @@ public class IntegrationTestGenerator {
     private static void explicitPromotionTest(final ISchemaVersion schemaVersion) throws IOException {
         final FileWriter output = openOutput(schemaVersion, "explicit_promotion", TestType.UNION);
 
-        final Random random = new Random(SEED);
+        final Random random = new Random(randomLong());
 
         // the accumulator, starts empty
         final HLL hll = newHLL(HLLType.EMPTY);
@@ -324,7 +321,7 @@ public class IntegrationTestGenerator {
     private static void sparseProbabilisticPromotionTest(final ISchemaVersion schemaVersion) throws IOException {
         final FileWriter output = openOutput(schemaVersion, "sparse_promotion", TestType.UNION);
 
-        final Random random = new Random(SEED);
+        final Random random = new Random(randomLong());
 
         // the accumulator, starts empty
         final HLL hll = newHLL(HLLType.EMPTY);
@@ -361,7 +358,7 @@ public class IntegrationTestGenerator {
     private static void explicitOverlapTest(final ISchemaVersion schemaVersion) throws IOException {
         final FileWriter output = openOutput(schemaVersion, "explicit_explicit", TestType.UNION);
 
-        final Random random = new Random(SEED);
+        final Random random = new Random(randomLong());
 
         // the accumulator, starts empty
         final HLL hll = newHLL(HLLType.EMPTY);
@@ -396,7 +393,7 @@ public class IntegrationTestGenerator {
     private static void sparseProbabilisticOverlapTest(final ISchemaVersion schemaVersion) throws IOException {
         final FileWriter output = openOutput(schemaVersion, "sparse_sparse", TestType.UNION);
 
-        final Random random = new Random(SEED);
+        final Random random = new Random(randomLong());
 
         // the accumulator, starts empty
         final HLL hll = newHLL(HLLType.EMPTY);
@@ -432,7 +429,7 @@ public class IntegrationTestGenerator {
     private static void probabilisticUnionTest(final ISchemaVersion schemaVersion) throws IOException {
         final FileWriter output = openOutput(schemaVersion, "probabilistic_probabilistic", TestType.UNION);
 
-        final Random random = new Random(SEED);
+        final Random random = new Random(randomLong());
 
         // the accumulator, starts empty
         final HLL hll = newHLL(HLLType.EMPTY);
@@ -464,8 +461,6 @@ public class IntegrationTestGenerator {
     private static void globalUnionTest(final ISchemaVersion schemaVersion) throws IOException {
         final FileWriter output = openOutput(schemaVersion, "comprehensive", TestType.UNION);
 
-        final Random random = new Random(SEED);
-
         // the accumulator, starts empty
         final HLL hll = newHLL(HLLType.EMPTY);
         final HLL emptyHLL = newHLL(HLLType.EMPTY);
@@ -473,7 +468,7 @@ public class IntegrationTestGenerator {
         cumulativeUnionLine(output, hll, emptyHLL, schemaVersion);
 
         for(int i=0; i<1000/*number of rows to generate*/; i++) {
-            final HLL randomHLL = generateRandomHLL(random);
+            final HLL randomHLL = generateRandomHLL();
             cumulativeUnionLine(output, hll, randomHLL, schemaVersion);
         }
 
@@ -548,8 +543,8 @@ public class IntegrationTestGenerator {
      *         the HLL. This cannot be <code>null</code>.
      * @return the populated HLL. This will never be <code>null</code>.
      */
-    public static HLL generateRandomHLL(final Random random) {
-        final int randomTypeInt = random.nextInt(HLLType.values().length);
+    public static HLL generateRandomHLL() {
+        final int randomTypeInt = randomIntBetween(0, HLLType.values().length - 1);
         final HLLType type;
         switch(randomTypeInt) {
             case 0:
@@ -595,10 +590,10 @@ public class IntegrationTestGenerator {
 
         final HLL hll = newHLL(HLLType.EMPTY);
         for(int i=0; i<cardinalityBaseline; i++) {
-            hll.addRaw(random.nextLong());
+            hll.addRaw(randomLong());
         }
-        for(int i=0; i<random.nextInt(cardinalityCap - cardinalityBaseline); i++) {
-            hll.addRaw(random.nextLong());
+        for(int i=0; i<randomInt(cardinalityCap - cardinalityBaseline); i++) {
+            hll.addRaw(randomLong());
         }
 
         return hll;

--- a/src/test/java/net/agkn/hll/SparseHLLTest.java
+++ b/src/test/java/net/agkn/hll/SparseHLLTest.java
@@ -16,16 +16,14 @@ package net.agkn.hll;
  * limitations under the License.
  */
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
+import static org.junit.Assert.*;
+import org.junit.Test;
 
 import java.util.Random;
 
 import net.agkn.hll.serialization.ISchemaVersion;
 import net.agkn.hll.serialization.SerializationUtil;
 import net.agkn.hll.util.HLLUtil;
-
-import org.testng.annotations.Test;
 
 import com.carrotsearch.hppc.IntByteHashMap;
 import com.carrotsearch.hppc.cursors.IntByteCursor;

--- a/src/test/java/net/agkn/hll/SparseHLLTest.java
+++ b/src/test/java/net/agkn/hll/SparseHLLTest.java
@@ -16,10 +16,7 @@ package net.agkn.hll;
  * limitations under the License.
  */
 
-import static org.junit.Assert.*;
 import org.junit.Test;
-
-import java.util.Random;
 
 import net.agkn.hll.serialization.ISchemaVersion;
 import net.agkn.hll.serialization.SerializationUtil;
@@ -27,13 +24,14 @@ import net.agkn.hll.util.HLLUtil;
 
 import com.carrotsearch.hppc.IntByteHashMap;
 import com.carrotsearch.hppc.cursors.IntByteCursor;
+import com.carrotsearch.randomizedtesting.RandomizedTest;
 
 /**
  * Tests {@link HLL} of type {@link HLLType#SPARSE}.
  *
  * @author timon
  */
-public class SparseHLLTest {
+public class SparseHLLTest extends RandomizedTest {
     private static final int log2m = 11;
 
     /**
@@ -396,16 +394,13 @@ public class SparseHLLTest {
         final int regwidth = 5/*arbitrary*/;
         final int sparseThreshold = 256/*arbitrary*/;
 
-        final long seed = 1L;
-        final Random random = new Random(seed);
-
         for(int run=0; run<100; run++) {
             final HLL hll = new HLL(log2m, regwidth, 128/*explicitThreshold, arbitrary, unused*/, sparseThreshold, HLLType.SPARSE);
 
             final IntByteHashMap map = new IntByteHashMap();
 
             for(int i=0; i<sparseThreshold; i++) {
-                final long rawValue = random.nextLong();
+                final long rawValue = randomLong();
 
                 final short registerIndex = ProbabilisticTestUtil.getRegisterIndex(rawValue, log2m);
                 final byte registerValue = ProbabilisticTestUtil.getRegisterValue(rawValue, log2m);

--- a/src/test/java/net/agkn/hll/SparseHLLTest.java
+++ b/src/test/java/net/agkn/hll/SparseHLLTest.java
@@ -16,10 +16,9 @@ package net.agkn.hll;
  * limitations under the License.
  */
 
-import static org.powermock.reflect.Whitebox.getInternalState;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
-import it.unimi.dsi.fastutil.ints.Int2ByteOpenHashMap;
+
 import java.util.Random;
 
 import net.agkn.hll.serialization.ISchemaVersion;
@@ -27,6 +26,9 @@ import net.agkn.hll.serialization.SerializationUtil;
 import net.agkn.hll.util.HLLUtil;
 
 import org.testng.annotations.Test;
+
+import com.carrotsearch.hppc.IntByteHashMap;
+import com.carrotsearch.hppc.cursors.IntByteCursor;
 
 /**
  * Tests {@link HLL} of type {@link HLLType#SPARSE}.
@@ -402,8 +404,7 @@ public class SparseHLLTest {
         for(int run=0; run<100; run++) {
             final HLL hll = new HLL(log2m, regwidth, 128/*explicitThreshold, arbitrary, unused*/, sparseThreshold, HLLType.SPARSE);
 
-            final Int2ByteOpenHashMap map = new Int2ByteOpenHashMap();
-            map.defaultReturnValue((byte)0);
+            final IntByteHashMap map = new IntByteHashMap();
 
             for(int i=0; i<sparseThreshold; i++) {
                 final long rawValue = random.nextLong();
@@ -417,9 +418,9 @@ public class SparseHLLTest {
                 hll.addRaw(rawValue);
             }
 
-            for(int key : map.keySet()) {
-                final byte expectedRegisterValue = map.get(key);
-                assertRegisterPresent(hll, key, expectedRegisterValue);
+            for (IntByteCursor c : map) {
+                final byte expectedRegisterValue = map.get(c.key);
+                assertRegisterPresent(hll, c.key, expectedRegisterValue);
             }
         }
     }
@@ -433,7 +434,7 @@ public class SparseHLLTest {
     private static void assertRegisterPresent(final HLL hll,
                                               final int registerIndex,
                                               final int registerValue) {
-        final Int2ByteOpenHashMap sparseProbabilisticStorage = (Int2ByteOpenHashMap)getInternalState(hll, "sparseProbabilisticStorage");
+        final IntByteHashMap sparseProbabilisticStorage = hll.sparseProbabilisticStorage;
         assertEquals(sparseProbabilisticStorage.get(registerIndex), registerValue);
     }
 
@@ -443,7 +444,7 @@ public class SparseHLLTest {
     private static void assertOneRegisterSet(final HLL hll,
                                              final int registerIndex,
                                              final byte registerValue) {
-        final Int2ByteOpenHashMap sparseProbabilisticStorage = (Int2ByteOpenHashMap)getInternalState(hll, "sparseProbabilisticStorage");
+        final IntByteHashMap sparseProbabilisticStorage = hll.sparseProbabilisticStorage;
         assertEquals(sparseProbabilisticStorage.size(), 1);
         assertEquals(sparseProbabilisticStorage.get(registerIndex), registerValue);
     }
@@ -452,11 +453,12 @@ public class SparseHLLTest {
      * Asserts that all registers in the two {@link HLL} instances are identical.
      */
     private static void assertElementsEqual(final HLL hllA, final HLL hllB) {
-        final Int2ByteOpenHashMap sparseProbabilisticStorageA = (Int2ByteOpenHashMap)getInternalState(hllA, "sparseProbabilisticStorage");
-        final Int2ByteOpenHashMap sparseProbabilisticStorageB = (Int2ByteOpenHashMap)getInternalState(hllB, "sparseProbabilisticStorage");
+        final IntByteHashMap sparseProbabilisticStorageA = hllA.sparseProbabilisticStorage;
+        final IntByteHashMap sparseProbabilisticStorageB = hllB.sparseProbabilisticStorage;
         assertEquals(sparseProbabilisticStorageA.size(), sparseProbabilisticStorageB.size());
-        for(final int index : sparseProbabilisticStorageA.keySet()) {
-            assertEquals(sparseProbabilisticStorageA.get(index), sparseProbabilisticStorageB.get(index));
+        for (IntByteCursor c : sparseProbabilisticStorageA) {
+            assertEquals(sparseProbabilisticStorageA.get(c.key), 
+                         sparseProbabilisticStorageB.get(c.key));
         }
     }
 }

--- a/src/test/java/net/agkn/hll/serialization/BigEndianAscendingWordDeserializerTest.java
+++ b/src/test/java/net/agkn/hll/serialization/BigEndianAscendingWordDeserializerTest.java
@@ -17,12 +17,10 @@ package net.agkn.hll.serialization;
  */
 
 
-import org.testng.annotations.Test;
 import java.util.Random;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
+import static org.junit.Assert.*;
+import org.junit.Test;
 
 /**
  * Unit and smoke tests for {@link BigEndianAscendingWordDeserializer}.
@@ -33,7 +31,6 @@ public class BigEndianAscendingWordDeserializerTest {
     /**
      * Error checking tests for constructor.
      */
-    @SuppressWarnings("unused")
     @Test
     public void constructorErrorTest() {
         // word length too small

--- a/src/test/java/net/agkn/hll/serialization/BigEndianAscendingWordDeserializerTest.java
+++ b/src/test/java/net/agkn/hll/serialization/BigEndianAscendingWordDeserializerTest.java
@@ -19,15 +19,16 @@ package net.agkn.hll.serialization;
 
 import java.util.Random;
 
-import static org.junit.Assert.*;
 import org.junit.Test;
+
+import com.carrotsearch.randomizedtesting.RandomizedTest;
 
 /**
  * Unit and smoke tests for {@link BigEndianAscendingWordDeserializer}.
  *
  * @author timon
  */
-public class BigEndianAscendingWordDeserializerTest {
+public class BigEndianAscendingWordDeserializerTest extends RandomizedTest {
     /**
      * Error checking tests for constructor.
      */
@@ -107,7 +108,7 @@ public class BigEndianAscendingWordDeserializerTest {
     @Test
     public void randomSmokeTest() {
         for(int wordLength=5; wordLength<65; wordLength++) {
-            runRandomTest(wordLength, 3/*bytePadding, arbitrary*/, 100000/*wordCount, arbitrary*/, (long)wordLength/*seed, arbitrary*/);
+            runRandomTest(wordLength, 3/*bytePadding, arbitrary*/, 100000/*wordCount, arbitrary*/);
         }
     }
 
@@ -120,7 +121,8 @@ public class BigEndianAscendingWordDeserializerTest {
      * @param wordCount the number of word values to test
      * @param seed the seed to the random value generator
      */
-    private static void runRandomTest(final int wordLength, final int bytePadding, final int wordCount, final long seed) {
+    private static void runRandomTest(final int wordLength, final int bytePadding, final int wordCount) {
+        final long seed = randomLong();
         final Random random = new Random(seed);
         final Random verificationRandom = new Random(seed);
 

--- a/src/test/java/net/agkn/hll/serialization/BigEndianAscendingWordSerializerTest.java
+++ b/src/test/java/net/agkn/hll/serialization/BigEndianAscendingWordSerializerTest.java
@@ -16,12 +16,10 @@ package net.agkn.hll.serialization;
  * limitations under the License.
  */
 
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
-
 import java.util.Arrays;
 
-import org.testng.annotations.Test;
+import static org.junit.Assert.*;
+import org.junit.Test;
 
 /**
  * Unit tests for {@link BigEndianAscendingWordSerializer}.
@@ -32,7 +30,6 @@ public class BigEndianAscendingWordSerializerTest {
     /**
      * Error checking tests for constructor.
      */
-    @SuppressWarnings("unused")
     @Test
     public void constructorErrorTest() {
         // word length too small

--- a/src/test/java/net/agkn/hll/serialization/HLLSerializationTest.java
+++ b/src/test/java/net/agkn/hll/serialization/HLLSerializationTest.java
@@ -2,7 +2,9 @@ package net.agkn.hll.serialization;
 
 import net.agkn.hll.HLL;
 import net.agkn.hll.HLLType;
-import org.testng.annotations.Test;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -14,7 +16,6 @@ import static net.agkn.hll.HLL.MAXIMUM_REGWIDTH_PARAM;
 import static net.agkn.hll.HLL.MINIMUM_EXPTHRESH_PARAM;
 import static net.agkn.hll.HLL.MINIMUM_LOG2M_PARAM;
 import static net.agkn.hll.HLL.MINIMUM_REGWIDTH_PARAM;
-import static org.testng.Assert.assertEquals;
 
 /**
  * Serialization smoke-tests.
@@ -34,11 +35,10 @@ public class HLLSerializationTest {
     public void serializationSmokeTest() throws Exception {
         final Random random = new Random(RANDOM_SEED);
         final int randomCount = 250;
-        final List<Long> randoms = new ArrayList<Long>(randomCount){{
-            for (int i=0; i<randomCount; i++) {
-                add(random.nextLong());
-            }
-        }};
+        final List<Long> randoms = new ArrayList<Long>(randomCount);
+        for (int i=0; i<randomCount; i++) {
+          randoms.add(random.nextLong());
+      }
 
         assertCardinality(HLLType.EMPTY, randoms);
         assertCardinality(HLLType.EXPLICIT, randoms);

--- a/src/test/java/net/agkn/hll/serialization/HLLSerializationTest.java
+++ b/src/test/java/net/agkn/hll/serialization/HLLSerializationTest.java
@@ -3,10 +3,12 @@ package net.agkn.hll.serialization;
 import net.agkn.hll.HLL;
 import net.agkn.hll.HLLType;
 
-import static org.junit.Assert.*;
 import org.junit.Test;
 
+import com.carrotsearch.randomizedtesting.RandomizedTest;
+
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Random;
@@ -23,17 +25,14 @@ import static net.agkn.hll.HLL.MINIMUM_REGWIDTH_PARAM;
  * @author yerenkow
  * @author benl
  */
-public class HLLSerializationTest {
-    // A fixed random seed so that this test is reproducible.
-    private static final long RANDOM_SEED = 1L;
-
+public class HLLSerializationTest extends RandomizedTest {
     /**
      * A smoke-test that covers serialization/deserialization of an HLL
      * under all possible parameters.
      */
     @Test
     public void serializationSmokeTest() throws Exception {
-        final Random random = new Random(RANDOM_SEED);
+        final Random random = new Random(randomLong());
         final int randomCount = 250;
         final List<Long> randoms = new ArrayList<Long>(randomCount);
         for (int i=0; i<randomCount; i++) {
@@ -65,12 +64,12 @@ public class HLLSerializationTest {
                         HLL copy = HLL.fromBytes(hll.toBytes());
                         assertEquals(copy.cardinality(), hll.cardinality());
                         assertEquals(copy.getType(), hll.getType());
-                        assertEquals(copy.toBytes(), hll.toBytes());
+                        assertTrue(Arrays.equals(copy.toBytes(), hll.toBytes()));
 
                         HLL clone = hll.clone();
                         assertEquals(clone.cardinality(), hll.cardinality());
                         assertEquals(clone.getType(), hll.getType());
-                        assertEquals(clone.toBytes(), hll.toBytes());
+                        assertTrue(Arrays.equals(clone.toBytes(), hll.toBytes()));
                     }
                 }
             }

--- a/src/test/java/net/agkn/hll/util/BitVectorTest.java
+++ b/src/test/java/net/agkn/hll/util/BitVectorTest.java
@@ -16,11 +16,8 @@ package net.agkn.hll.util;
  * limitations under the License.
  */
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
-
-import org.testng.annotations.Test;
+import static org.junit.Assert.*;
+import org.junit.Test;
 
 /**
  * Unit tests for {@link BitVector}.
@@ -118,11 +115,11 @@ public class BitVectorTest {
         final LongIterator iter = vector.registerIterator();
 
         for(int i=0; i<count; i++) {
-            assertTrue(iter.hasNext(), String.format("expected more elements: width=%s, count=%s", width, count));
+            assertTrue(String.format("expected more elements: width=%s, count=%s", width, count), iter.hasNext());
             // TODO: fill with a sentinel value
             assertEquals(iter.next(), 0);
         }
-        assertFalse(iter.hasNext(), String.format("expected no more elements: width=%s, count=%s", width, count));
+        assertFalse(String.format("expected no more elements: width=%s, count=%s", width, count), iter.hasNext());
     }
 
     // ========================================================================

--- a/src/test/java/net/agkn/hll/util/HLLUtilTest.java
+++ b/src/test/java/net/agkn/hll/util/HLLUtilTest.java
@@ -41,7 +41,7 @@ public class HLLUtilTest {
                 // and original paper (Fig. 3) for information on 2^L and
                 // "large range correction" cutoff.
                 final double expected = Math.pow(2, Math.pow(2, regWidth) - 2 + log2m) / 30.0;
-                assertEquals(cutoff, expected);
+                assertEquals(cutoff, expected, 0.0001);
             }
         }
     }

--- a/src/test/java/net/agkn/hll/util/HLLUtilTest.java
+++ b/src/test/java/net/agkn/hll/util/HLLUtilTest.java
@@ -16,10 +16,10 @@ package net.agkn.hll.util;
  * limitations under the License.
  */
 
-import static org.testng.Assert.assertEquals;
 import net.agkn.hll.HLL;
 
-import org.testng.annotations.Test;
+import static org.junit.Assert.*;
+import org.junit.Test;
 
 /**
  * Tests {@link HLLUtil} static methods.


### PR DESCRIPTION
Hello,

This patch migrates the code from fastutil to HPPC collections. The difference is in size -- HPPC is about 15x smaller than fastutil and hll only requires a tiny set of functionality.

I've also migrated from testng to plain JUnit to be able to randomize tests (instead of running on a fixed seed all the time).

All tests pass with this change. Let me know if you're interested in incorporating it into the main line.
